### PR TITLE
Install the enterprise from custom url

### DIFF
--- a/src/main/java/io/cloudsoft/basho/RiakEnterpriseNodeImpl.java
+++ b/src/main/java/io/cloudsoft/basho/RiakEnterpriseNodeImpl.java
@@ -1,8 +1,25 @@
 package io.cloudsoft.basho;
 
+import brooklyn.entity.nosql.riak.RiakNode;
 import brooklyn.entity.nosql.riak.RiakNodeImpl;
+import brooklyn.event.basic.AttributeSensorAndConfigKey;
+import com.google.api.client.repackaged.com.google.common.base.Preconditions;
 
 public class RiakEnterpriseNodeImpl extends RiakNodeImpl implements RiakEnterpriseNode {
+
+    @Override
+    public void init() {
+        super.init();
+
+        AttributeSensorAndConfigKey[] downloadProperties = {RiakNode.DOWNLOAD_URL_DEBIAN, RiakNode.DOWNLOAD_URL_UBUNTU, RiakNode.DOWNLOAD_URL_RHEL_CENTOS};
+        String[] mapDownloadPropertiesToString = new String[downloadProperties.length];
+        for(int i = 0; i < downloadProperties.length; i++) {
+            mapDownloadPropertiesToString[i] = downloadProperties[i].getName();
+        }
+
+        Preconditions.checkNotNull(isPackageDownloadUrlProvided() ? RiakNode.DOWNLOAD_URL_RHEL_CENTOS : null,
+                "For the enterprise version, You have to specify some of the possible: " + org.apache.commons.lang.StringUtils.join(mapDownloadPropertiesToString, ','));
+    }
 
    @Override
    public RiakEnterpriseNodeDriver getDriver() {

--- a/src/main/java/io/cloudsoft/basho/RiakEnterpriseNodeSshDriver.java
+++ b/src/main/java/io/cloudsoft/basho/RiakEnterpriseNodeSshDriver.java
@@ -4,7 +4,6 @@ import brooklyn.entity.Entity;
 import brooklyn.entity.basic.Attributes;
 import brooklyn.entity.basic.EntityPredicates;
 import brooklyn.entity.basic.lifecycle.ScriptHelper;
-import brooklyn.entity.nosql.riak.RiakCluster;
 import brooklyn.entity.nosql.riak.RiakNodeImpl;
 import brooklyn.entity.nosql.riak.RiakNodeSshDriver;
 import brooklyn.entity.software.SshEffectorTasks;
@@ -75,6 +74,6 @@ public class RiakEnterpriseNodeSshDriver extends RiakNodeSshDriver implements Ri
     }
 
     private String getRiakReplCommand() {
-        return isPackageInstall() ? "riak-repl" : Urls.mergePaths(getExpandedInstallDir(), "bin/riak-repl");
+        return "riak-repl";
     }
 }


### PR DESCRIPTION
This is a pull request which has to be reviewed
together with https://github.com/apache/incubator-brooklyn/pull/531

This pull request makes possible the installation from url which is necessary for the enteprise version.
Previously this was done in the open source version but since we changed it in #531
to be installed from packagecloud.io I moved the custom Url here
